### PR TITLE
Bugfix

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1,5 +1,4 @@
 doc_config
-
 ===========
 Holds the configuration.
 

--- a/doc/object.md
+++ b/doc/object.md
@@ -1,5 +1,4 @@
 doc_object
-
 ===========
 A linked list of objects.
 

--- a/doc/object_function.md
+++ b/doc/object_function.md
@@ -1,5 +1,4 @@
 doc_function
-
 =============
 Represents a function.
 

--- a/doc/object_struct.md
+++ b/doc/object_struct.md
@@ -1,5 +1,4 @@
 doc_struct
-
 ===========
 Represents a struct.
 

--- a/src/exports/export_md.c
+++ b/src/exports/export_md.c
@@ -67,7 +67,6 @@ export_md_struct (struct doc_struct *self, FILE *f_doc)
 {
 	// Name
 	fputs (self->name, f_doc);
-	fputs ("\n", f_doc);
 	
 	// Underline
 	for (size_t i = 0; i < strlen (self->name); i++)


### PR DESCRIPTION
Bugfix: The name of structs has already a newline so the extra newline disables the underline header. :rotating_light: 