### PR TITLE
Replace the underline with '#'.

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1,5 +1,4 @@
-doc_config
-==========
+#doc_config
 Holds the configuration.
 
 **Members**
@@ -9,8 +8,7 @@ Holds the configuration.
 pattern | Customizable patterns.
 
 
-config_init
-===========
+#config_init
 Initialize a config structure.
 
 **Parameters**
@@ -22,8 +20,7 @@ self | Pointer to the structure to init.
 **Returns**
 none
 
-config_free
-===========
+#config_free
 Free's the allocated memory of a config
 structure.
 
@@ -35,4 +32,3 @@ self | Pointer to the structure to free.
 
 **Returns**
 none
-

--- a/doc/export_md.md
+++ b/doc/export_md.md
@@ -1,23 +1,4 @@
-
-
-export_md_underline
-===================
-Writes @str with a underline made of @fill
-to the @f_doc stream.
-
-**Parameters**
-
-**Name** | **Description**
--------- | ---------------
-str | String to output with an underline.
-fill | String to output as underline.
-f_doc | Stream to which the output gets written.
-
-**Returns**
-none
-
-export_md_function
-==================
+#export_md_function
 Exports a function object to the file @f_doc
 in Markdown.
 
@@ -31,8 +12,7 @@ f_doc | Stream to which the data gets written.
 **Returns**
 none
 
-export_md_struct
-================
+#export_md_struct
 Exports a struct object to the file @f_doc
 in Markdown.
 
@@ -46,8 +26,7 @@ f_doc | Stream to which the data gets written.
 **Returns**
 none
 
-export_md
-=========
+#export_md
 Exports the @nodes in Markdown to a file named @filename.
 
 **Parameters**
@@ -59,4 +38,3 @@ filename | The name of the documentation file.
 
 **Returns**
 none
-

--- a/doc/node.md
+++ b/doc/node.md
@@ -1,5 +1,4 @@
-doc_node
-========
+#doc_node
 A linked list of objects.
 
 **Members**
@@ -12,8 +11,7 @@ name | Name of the node;
 next | Address of the next entry.
 
 
-node_init
-=========
+#node_init
 Initializes a node structure and its element.
 
 **Parameters**
@@ -27,8 +25,7 @@ name | Name of the node.
 **Returns**
 none
 
-node_append
-===========
+#node_append
 Appends an entry to the linked list.
 
 **Parameters**
@@ -42,8 +39,7 @@ element | The element.
 **Returns**
 Pointer to the list head.
 
-node_free
-=========
+#node_free
 Frees the whole linked list.
 
 **Parameters**
@@ -54,4 +50,3 @@ list | List head.
 
 **Returns**
 none
-

--- a/doc/object.md
+++ b/doc/object.md
@@ -1,5 +1,4 @@
-doc_object
-==========
+#doc_object
 Stores the documentation informations.
 
 **Members**
@@ -12,8 +11,7 @@ returns | Description of what the object returns.
 members | String list storing the members.
 
 
-object_init
-===========
+#object_init
 Initialize's a doc_object structure.
 
 **Parameters**
@@ -25,8 +23,7 @@ self | The structure itself.
 **Returns**
 none
 
-object_free
-===========
+#object_free
 Free's the allocated memory of a doc_object structure.
 
 **Parameters**
@@ -38,8 +35,7 @@ self | The structure itself.
 **Returns**
 none
 
-object_member_insert
-====================
+#object_member_insert
 Insert a new member to the doc_object.
 
 **Parameters**
@@ -52,4 +48,3 @@ description | Description of the member.
 
 **Returns**
 none
-

--- a/doc/parser.md
+++ b/doc/parser.md
@@ -1,7 +1,4 @@
-
-
-parse_object
-============
+#parse_object
 Parses fields of a doc_object.
 
 **Parameters**
@@ -14,8 +11,7 @@ cursor | String to parse.
 **Returns**
 none
 
-parse_node
-==========
+#parse_node
 Parses a node type and initialize it.
 
 **Parameters**
@@ -28,8 +24,7 @@ cursor | String to parse.
 **Returns**
 none
 
-parse_file
-==========
+#parse_file
 Parses a source file and returns a doc_node linked list
 which contains the information gathered from the source file.
 
@@ -43,4 +38,3 @@ filename | Name of the source file.
 
 **Returns**
 A linked list containing the information.
-

--- a/doc/string_utils.md
+++ b/doc/string_utils.md
@@ -1,5 +1,4 @@
-string_match_start
-==================
+#string_match_start
 Checks if the string @str starts with
 the pattern @pat.
 
@@ -13,8 +12,7 @@ pat | Pattern to search for.
 **Returns**
 If the pattern is found true, otherwise false.
 
-string_match_end
-================
+#string_match_end
 Checks if the string @str ends with
 the pattern @pat.
 
@@ -28,8 +26,7 @@ pat | Pattern to search for.
 **Returns**
 If the pattern is found true, otherwise false.
 
-string_recat
-============
+#string_recat
 Allocates the memory needed to append @src to @dest
 and append @src to @dest.
 
@@ -43,8 +40,7 @@ src | String to append.
 **Returns**
 Location of @dest.
 
-string_cut_end
-==============
+#string_cut_end
 Builds a new string containing @str
 without the @end string.
 This should be faster than strspan_c.
@@ -60,8 +56,7 @@ end | End sequence to remove.
 **Returns**
 A new allocated string.
 
-strspan_c
-=========
+#strspan_c
 A simple shortcut.
 The returned string should be freed with free().
 
@@ -75,8 +70,7 @@ end | End sequence.
 **Returns**
 A new allocated substring of @str that ends at @end.
 
-strspan
-=======
+#strspan
 Cuts the part between @start and @end out of
 the string @str and paste it into allocated memory.
 The returned string should be freed with free().

--- a/doc/strlist.md
+++ b/doc/strlist.md
@@ -1,7 +1,4 @@
-
-
-strlist_insert
-==============
+#strlist_insert
 Inserts an entry into a string list.
 
 **Parameters**
@@ -15,8 +12,7 @@ len | Amount of entries in the string list (including this one).
 **Returns**
 The new address of @strlist.
 
-strlist_free
-============
+#strlist_free
 Frees a string list if it has entries.
 
 **Parameters**
@@ -29,4 +25,3 @@ len | Amount of entries in the string list.
 
 **Returns**
 none
-

--- a/src/exports/export_md.c
+++ b/src/exports/export_md.c
@@ -8,33 +8,6 @@
 #include "export_md.h"
 
 /**
- * export_md_underline()
- * @str - String to output with an underline.
- * @fill - String to output as underline.
- * @f_doc - Stream to which the output gets written.
- *
- * Writes @str with a underline made of @fill
- * to the @f_doc stream.
- *
- * Return: none
- */
-static void
-export_md_underline (const char *str, const char *fill, FILE *f_doc)
-{
-	// Output the string
-	fputs (str, f_doc);
-	fputs ("\n", f_doc);
-	
-	const size_t str_len = strlen (str);
-	// Output the underline
-	for (size_t i = 0; i < str_len; i++)
-	{
-		fputs (fill, f_doc);
-	}
-	fputs ("\n", f_doc);
-}
-
-/**
  * export_md_function()
  * @self - The function data.
  * @f_doc - Stream to which the data gets written.
@@ -129,8 +102,10 @@ export_md (struct doc_node *nodes, const char *filename)
 	struct doc_node *next = nodes;
 	while (next)
 	{
-		// The name of the object with an underline
-		export_md_underline (next->name, "=", f_doc);
+		// The name of the object as H1
+		fputc ('#', f_doc);
+		fputs (next->name, f_doc);
+		fputc ('\n', f_doc);
 		
 		switch (next->type)
 		{


### PR DESCRIPTION
* Use '#' instead of an underline to create a heading.
* Rebuild the documentation using this version.