### PR TITLE
Titles wont be recognized

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,7 @@
-#Documentation
+# Documentation
 This folder contains the documentation of Doctras source code, created with Doctra itself.
 
-##Building the documentation
+## Building the documentation
 To build the documentation run the `makedoc.sh` script while inside the `doc` folder.
 ```SH
 $ ./makedoc.sh

--- a/doc/config.md
+++ b/doc/config.md
@@ -1,4 +1,4 @@
-#doc_config
+# doc_config
 Holds the configuration.
 
 **Members**
@@ -8,7 +8,7 @@ Holds the configuration.
 pattern | Customizable patterns.
 
 
-#config_init
+# config_init
 Initialize a config structure.
 
 **Parameters**
@@ -20,7 +20,7 @@ self | Pointer to the structure to init.
 **Returns**
 none
 
-#config_free
+# config_free
 Free's the allocated memory of a config
 structure.
 

--- a/doc/export_md.md
+++ b/doc/export_md.md
@@ -1,4 +1,4 @@
-#export_md_function
+# export_md_function
 Exports a function object to the file @f_doc
 in Markdown.
 
@@ -12,7 +12,7 @@ f_doc | Stream to which the data gets written.
 **Returns**
 none
 
-#export_md_struct
+# export_md_struct
 Exports a struct object to the file @f_doc
 in Markdown.
 
@@ -26,7 +26,7 @@ f_doc | Stream to which the data gets written.
 **Returns**
 none
 
-#export_md
+# export_md
 Exports the @nodes in Markdown to a file named @filename.
 
 **Parameters**

--- a/doc/node.md
+++ b/doc/node.md
@@ -1,4 +1,4 @@
-#doc_node
+# doc_node
 A linked list of objects.
 
 **Members**
@@ -11,7 +11,7 @@ name | Name of the node;
 next | Address of the next entry.
 
 
-#node_init
+# node_init
 Initializes a node structure and its element.
 
 **Parameters**
@@ -25,7 +25,7 @@ name | Name of the node.
 **Returns**
 none
 
-#node_append
+# node_append
 Appends an entry to the linked list.
 
 **Parameters**
@@ -39,7 +39,7 @@ element | The element.
 **Returns**
 Pointer to the list head.
 
-#node_free
+# node_free
 Frees the whole linked list.
 
 **Parameters**

--- a/doc/object.md
+++ b/doc/object.md
@@ -1,4 +1,4 @@
-#doc_object
+# doc_object
 Stores the documentation informations.
 
 **Members**
@@ -11,7 +11,7 @@ returns | Description of what the object returns.
 members | String list storing the members.
 
 
-#object_init
+# object_init
 Initialize's a doc_object structure.
 
 **Parameters**
@@ -23,7 +23,7 @@ self | The structure itself.
 **Returns**
 none
 
-#object_free
+# object_free
 Free's the allocated memory of a doc_object structure.
 
 **Parameters**
@@ -35,7 +35,7 @@ self | The structure itself.
 **Returns**
 none
 
-#object_member_insert
+# object_member_insert
 Insert a new member to the doc_object.
 
 **Parameters**

--- a/doc/parser.md
+++ b/doc/parser.md
@@ -1,4 +1,4 @@
-#parse_object
+# parse_object
 Parses fields of a doc_object.
 
 **Parameters**
@@ -11,7 +11,7 @@ cursor | String to parse.
 **Returns**
 none
 
-#parse_node
+# parse_node
 Parses a node type and initialize it.
 
 **Parameters**
@@ -24,7 +24,7 @@ cursor | String to parse.
 **Returns**
 none
 
-#parse_file
+# parse_file
 Parses a source file and returns a doc_node linked list
 which contains the information gathered from the source file.
 

--- a/doc/string_utils.md
+++ b/doc/string_utils.md
@@ -1,4 +1,4 @@
-#string_match_start
+# string_match_start
 Checks if the string @str starts with
 the pattern @pat.
 
@@ -12,7 +12,7 @@ pat | Pattern to search for.
 **Returns**
 If the pattern is found true, otherwise false.
 
-#string_match_end
+# string_match_end
 Checks if the string @str ends with
 the pattern @pat.
 
@@ -26,7 +26,7 @@ pat | Pattern to search for.
 **Returns**
 If the pattern is found true, otherwise false.
 
-#string_recat
+# string_recat
 Allocates the memory needed to append @src to @dest
 and append @src to @dest.
 
@@ -40,7 +40,7 @@ src | String to append.
 **Returns**
 Location of @dest.
 
-#string_cut_end
+# string_cut_end
 Builds a new string containing @str
 without the @end string.
 This should be faster than strspan_c.
@@ -56,7 +56,7 @@ end | End sequence to remove.
 **Returns**
 A new allocated string.
 
-#strspan_c
+# strspan_c
 A simple shortcut.
 The returned string should be freed with free().
 
@@ -70,7 +70,7 @@ end | End sequence.
 **Returns**
 A new allocated substring of @str that ends at @end.
 
-#strspan
+# strspan
 Cuts the part between @start and @end out of
 the string @str and paste it into allocated memory.
 The returned string should be freed with free().

--- a/doc/strlist.md
+++ b/doc/strlist.md
@@ -1,4 +1,4 @@
-#strlist_insert
+# strlist_insert
 Inserts an entry into a string list.
 
 **Parameters**
@@ -12,7 +12,7 @@ len | Amount of entries in the string list (including this one).
 **Returns**
 The new address of @strlist.
 
-#strlist_free
+# strlist_free
 Frees a string list if it has entries.
 
 **Parameters**

--- a/src/exports/export_md.c
+++ b/src/exports/export_md.c
@@ -103,7 +103,7 @@ export_md (struct doc_node *nodes, const char *filename)
 	while (next)
 	{
 		// The name of the object as H1
-		fputc ('#', f_doc);
+		fputs ("# ", f_doc);
 		fputs (next->name, f_doc);
 		fputc ('\n', f_doc);
 		


### PR DESCRIPTION
Fixes the bug that causes the generated Markdown files contain titles that would not be recognized by GitHub's renderer.